### PR TITLE
Adding support for getting Metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -234,6 +234,32 @@ Files.prototype.createMetadata = function (file, metadata, callback) {
     });
 };
 
+// Retrieves metadata for a given file
+Files.prototype.getAllMetadata = function(file, callback){
+  request
+    .get(this.options.base_url+'/'+this.resource+'/'+file+'/metadata/')
+    .set('Authorization', this.options.auth)
+    .end(function(res){
+      if(res.error)
+        return callback('Error: '+res.error.message);
+
+      callback(null, res.body);
+    });
+};
+
+// Retrieves specific metadata (defined by <path>) for a given file
+Files.prototype.getMetadata = function(file, path, callback){
+  request
+    .get(this.options.base_url+'/'+this.resource+'/'+file+'/metadata/'+path)
+    .set('Authorization', this.options.auth)
+    .end(function(res){
+      if(res.error)
+        return callback('Error: '+res.error.message);
+
+      callback(null, res.body);
+    });
+};
+
 Files.prototype.createSharedLink = function(file, sharedLinkSettings, callback) {
   if (typeof sharedLinkSettings === 'function') {
     callback = sharedLinkSettings;


### PR DESCRIPTION
Added two new endpoints; `files.getAllMetadata` that retrieves all metadata for a given file
as well as `files.getMetadata` that allows you to define a specific path to a metadata entry
