### PR TITLE
Implement file upload without name test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ Search.prototype.new = function (query, params, callback) {
     var keys = Object.keys(params);
     for (var i = 0, len = keys.length; i < len; i++) {
       var key = keys[i];
-     
+
       uri += '&'+key+'='+params[key];
     }
   }
@@ -107,7 +107,7 @@ Search.prototype.new = function (query, params, callback) {
 
       callback(null, res.body);
     });
-}
+};
 
 
 // Files Resource

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "superagent": "~0.18.0"
   },
   "devDependencies": {
-    "prova": "latest"
+    "nock": "latest",
+    "prova": "latest",
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var Box = require('../lib/'),
-    test = require('prova'),
+    nock = require('nock'),
     path = require('path'),
-    async = require('async');
+    test = require('prova');
 
 var fs = require('fs'),
     request = require('superagent');
@@ -9,4 +9,27 @@ var fs = require('fs'),
 
 var box = new Box({
   access_token: 'null'
+});
+
+test('file.upload without custom filename', function (t) {
+  t.plan(1);
+  var boxFileId = 'box-file-id',
+      uploadFileName = 'a.txt',
+      filepath = __dirname + '/' + uploadFileName,
+      folderId = '1234';
+
+  nock(box.options.upload_url)
+  .post('/files/content', function(body) {
+    folderIdParamRegex = 'name="parent_id"' + folderId;
+    filenameParamRegex = 'name="filename"; filename="' + uploadFileName + '"';
+    return body.match(folderIdParamRegex) && body.match(filenameParamRegex);
+  })
+  .reply(201, { id: boxFileId });
+
+  box.files.upload(filepath, folderId, function(err, success) {
+    if (err) {
+        throw err;
+    }
+    t.equal(success.id, boxFileId);
+  });
 });


### PR DESCRIPTION
- Adds a test for `files.upload` (without custom name).
- Adds `nock` as a `devDependency` for testing.

I'd enjoy any feedback on the approach I took and would also be happy to
add coverage to some of the other functions if we're happy with the
general direction here.

Conversation started in
https://github.com/Skycatch/node-box/pull/3#issuecomment-136026675
