### PR TITLE
Fixed box.search.new

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,18 +84,16 @@ Search.prototype.new = function (query, params, callback) {
     callback = params;
     params = null;
   }
-  var uri = this.options.base_url+'/'+this.resource + '?query=' + query;
+  var uri = this.options.base_url+'/'+this.resource + '?query=' + encodeURIComponent(query);
 
   if (params) {
     var keys = Object.keys(params);
     for (var i = 0, len = keys.length; i < len; i++) {
       var key = keys[i];
 
-      uri += '&'+key+'='+params[key];
+      uri += '&'+key+'='+encodeURIComponent(params[key]);
     }
   }
-
-  uri = encodeURIComponent(uri);
 
   request
     .get(uri)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "nock": "latest",
-    "prova": "latest",
+    "prova": "latest"
   }
 }


### PR DESCRIPTION
box.search.new was throwing a TypeError because of the way the uri was being encoded, also NPM was failing to install because package.json had a trailing comma.
